### PR TITLE
Fix AHCS mapping

### DIFF
--- a/data-shaping/output/output.py
+++ b/data-shaping/output/output.py
@@ -557,7 +557,7 @@ def transfer_trainees(path, sheets):
                 hcpc_counter_signoff_required=row['RGHCSREQ'],
                 hcpc_signoff_name=row['RGHCNM'],
                 hcpc_signoff_number=row['RGHCNUM'],
-                ahcs_registration=row['RGHCNUM'],
+                ahcs_registration=row['RGAHCS'],
                 portfolio_extended=row['RGOLEXT']
                 )
 


### PR DESCRIPTION
Noticed thos while doing the import

The field was mapped to a wrong column from excel (in this case - HCPC_SIGNOFF_NUM)

I've inspected the sample data - there's no such column present at all, although data table references does mention it....

I'm not sure how the script would react when trying to read from non-existing column, @alexandar1000 any ideas?

this is not blocking atm as I will simply remove all values for `ahcs_registration` field for now
